### PR TITLE
Image synchronization

### DIFF
--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -33,10 +33,10 @@ that does not need to update much while other objects moves a lot on the screen.
     - observe some of its attributes and call functions when they change
     - link some of its attributes to other widget attributes
 
-Clear canvas
+Clear Canvas
 ------------
 
-The ``Canvas`` class has a ``clear`` method which allows to clear the entire canvas.
+The ``Canvas`` and ``MultiCanvas`` classes have a ``clear`` method which allows to clear the entire canvas.
 
 .. code:: Python
 
@@ -47,6 +47,37 @@ The ``Canvas`` class has a ``clear`` method which allows to clear the entire can
     # Perform some drawings...
 
     canvas.clear()
+
+Save Canvas to a file
+---------------------
+
+You can dump the current ``Canvas`` or ``MultiCanvas`` image using the ``to_file`` method. You first need to specify that you want the image data to be synchronized between the front-end and the back-end setting the ``sync_image_data`` attribute to ``True``.
+
+.. code:: Python
+
+    from ipycanvas import Canvas
+
+    canvas = Canvas(size=(200, 200), sync_image_data=True)
+
+    # Perform some drawings...
+
+    canvas.to_file('my_file.png')
+
+Note that this won't work if executed in the same Notebook cell. Because the Canvas won't have drawn anything yet. If you want to put all your code in the same Notebook cell, you need to define a callback function that will be called when the Canvas is ready to be dumped to an image file.
+
+.. code:: Python
+
+    from ipycanvas import Canvas
+
+    canvas = Canvas(size=(200, 200), sync_image_data=True)
+
+    # Perform some drawings...
+
+    def save_to_file(*args, **kwargs):
+        canvas.to_file('my_file.png')
+
+    # Listen to changes on the ``image_data`` trait and call ``save_to_file`` when it changes.
+    canvas.observe(save_to_file, 'image_data')
 
 Optimizing drawings
 -------------------

--- a/examples/plotting.ipynb
+++ b/examples/plotting.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "def init_2d_plot(x, y, color=None, scheme=branca.colormap.linear.RdBu_11, canvas=None, canvas_size=(800, 600), padding=0.1):\n",
     "    if canvas is None:\n",
-    "        canvas = MultiCanvas(3, size=canvas_size)\n",
+    "        canvas = MultiCanvas(3, size=canvas_size, sync_image_data=True)\n",
     "    else:\n",
     "        canvas.size = canvas_size\n",
     "\n",
@@ -280,6 +280,27 @@
     "\n",
     "plot = scatter_plot(x, y, sizes, colors, branca.colormap.linear.viridis, stroke_color='white')\n",
     "plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save the plot to an image file!\n",
+    "plot.to_file('my_scatter.png')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import Image\n",
+    "\n",
+    "Image.from_file('my_scatter.png')"
    ]
   },
   {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,3 +71,35 @@ function getArg(metadata: any, buffers: any) : Arg {
 
   throw 'Could not process argument ' + metadata;
 }
+
+export
+async function toBlob(canvas: HTMLCanvasElement) : Promise<Blob> {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob == null) {
+        return reject('Unable to create blob');
+      }
+
+      resolve(blob);
+    });
+  });
+}
+
+export
+async function toBytes(canvas: HTMLCanvasElement) : Promise<Uint8ClampedArray> {
+  const blob = await toBlob(canvas);
+
+  return new Promise<Uint8ClampedArray>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onloadend = () => {
+        if (typeof reader.result == 'string' || reader.result == null) {
+          return reject('Unable to read blob');
+        }
+
+        const bytes = new Uint8ClampedArray(reader.result);
+        resolve(bytes);
+    };
+    reader.readAsArrayBuffer(blob);
+  });
+}


### PR DESCRIPTION
Fix #32 and fix #46 

We synchronize the image as raw bytes, PNG encoded. This is **way faster** than synchronizing all the pixels with NumPy arrays. We can include a `get_image_data` method that would turn those bytes into a NumPy array later on.

- [x] Docs
- [x] Make it work with MultiCanvas