### PR TITLE
Clear the canvas in CanvasView before drawing

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -328,6 +328,7 @@ class CanvasView extends DOMWidgetView {
   }
 
   updateCanvas() {
+    this.clear();	
     this.ctx.drawImage(this.model.canvas, 0, 0);
   }
 


### PR DESCRIPTION
If the CanvasView doesn't clear the canvas before copying from
the master canvas, transpartent parts originating from clear_rect
will not appear in the CanvasViews. See issue martinRenou/ipycanvas#58.
