### PR TITLE
Draw synced data at canvas creation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,3 +103,18 @@ async function toBytes(canvas: HTMLCanvasElement) : Promise<Uint8ClampedArray> {
     reader.readAsArrayBuffer(blob);
   });
 }
+
+export
+async function fromBytes(array: Uint8ClampedArray) : Promise<HTMLImageElement> {
+  const blob = new Blob([array]);
+
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+
+    img.onload = () => {
+      resolve(img);
+    }
+
+    img.src = URL.createObjectURL(blob);
+  });
+}


### PR DESCRIPTION
This will fix #64 

It also allows retrieving the canvas image when refreshing the page:
![refresh](https://user-images.githubusercontent.com/21197331/72552076-6345f380-3896-11ea-83d3-7d16157327de.gif)

This is only possible when setting `sync_image_data` to `True`