### PR TITLE
Add .d.ts files to package.json includes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   ],
   "files": [
     "lib/**/*.js",
-    "dist/*.js"
+    "lib/**/*.d.ts",
+    "dist/*.js",
+    "dist/*.d.ts"
   ],
   "homepage": "https://github.com/martinRenou/ipycanvas",
   "bugs": {


### PR DESCRIPTION
This adds the `.d.ts` files to the includes list so that they can be bundled in the published npm package, and so that the canvas objects can be easily re-used by other typescript-based plugins.