### PR TITLE
missing styled batch methods for rects and arcs

### DIFF
--- a/examples/batch_drawing.ipynb
+++ b/examples/batch_drawing.ipynb
@@ -11,19 +11,115 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 46,
    "id": "3ea1b15d-478b-41a2-83a1-3e66e5ff5d24",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from ipycanvas import Canvas, hold_canvas"
+    "from ipycanvas import Canvas, hold_canvas\n",
+    "import math"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3b9c73f-d4fe-4c80-978e-60f4932c69d7",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Batch Draw Rects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "7de46419-aefa-4039-a27c-ad92f903a5ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4f16d21e2fa442d9b215ed9f5c7b7ef3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(height=300, width=800)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "canvas = Canvas(width=800, height=300)\n",
+    "n_rects = 1000\n",
+    "x = np.random.randint(0, canvas.width, size=(n_rects))\n",
+    "y = np.random.randint(0, canvas.width, size=(n_rects))\n",
+    "width = np.random.randint(10, 40, size=(n_rects))\n",
+    "height = np.random.randint(10, 40, size=(n_rects))\n",
+    "with hold_canvas(canvas):\n",
+    "    canvas.fill_style = 'cyan'\n",
+    "    canvas.fill_rects(x, y, width, height)\n",
+    "    canvas.line_width = 2\n",
+    "    canvas.stroke_style = 'black'\n",
+    "    canvas.stroke_rects(x, y, width, height)\n",
+    "canvas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd1cb3db-2ceb-49d3-87aa-9929b262a066",
+   "metadata": {},
+   "source": [
+    "# Batch Draw Styled Rects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "f051cd10-5cf3-4a6f-bcb3-d10d5528c185",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b9af46082601430fabb28f7dc57484a7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(height=300, width=800)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "canvas = Canvas(width=800, height=300)\n",
+    "n_rects = 1000\n",
+    "x = np.random.randint(0, canvas.width, size=(n_rects))\n",
+    "y = np.random.randint(0, canvas.width, size=(n_rects))\n",
+    "width = np.random.randint(10, 40, size=(n_rects))\n",
+    "height = np.random.randint(10, 40, size=(n_rects))\n",
+    "colors_fill = np.random.randint(0, 255, size=(n_rects,3))\n",
+    "colors_outline  = np.random.randint(0, 255, size=(n_rects,3))\n",
+    "alphas = np.random.random(n_rects)\n",
+    "with hold_canvas(canvas):\n",
+    "    canvas.fill_styled_rects(x, y, width, height, color=colors_fill,alpha=alphas)\n",
+    "    canvas.line_width = 2\n",
+    "    canvas.stroke_styled_rects(x, y, width, height, color=colors_outline,alpha=alphas)\n",
+    "canvas"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "2117b808-65d2-44dd-a780-dd9100809a68",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Batch Draw Circles\n",
     "draw many circles each cirlcle has the same color"
@@ -31,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 48,
    "id": "82b532b6-06b0-4255-b4fa-e03a6363ddf0",
    "metadata": {
     "tags": []
@@ -40,7 +136,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "92b6da42c15842298d3faf678a6381fa",
+       "model_id": "2d3f918019954eb49bf2e2985a2f152c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -81,14 +177,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 49,
    "id": "ce545eee-d9c0-47ab-afb7-274fa22389cd",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e209d607b8de4226a5dbff72536b0ec7",
+       "model_id": "11134765d61041fd9395b155ef309910",
        "version_major": 2,
        "version_minor": 0
       },
@@ -118,8 +214,110 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afea33c6-c6a8-4528-a1d9-7535a6810e9a",
+   "id": "279d10b5-ed1b-4fa6-8bbe-f25313ad0475",
    "metadata": {},
+   "source": [
+    "# Batch Draw Arcs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "e36c1407-9a46-42fa-b06a-1a8283feee86",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "66ae6bd2dbfe4d4eb530b33054e1d2ba",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(height=300, width=800)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "canvas = Canvas(width=800, height=300)\n",
+    "n_circles = 1000\n",
+    "x = np.random.randint(0, canvas.width, size=(n_circles))\n",
+    "y = np.random.randint(0, canvas.width, size=(n_circles))\n",
+    "r = np.random.randint(10, 20, size=(n_circles))\n",
+    "start_angle = np.random.randint(0, 360, size=(n_circles))\n",
+    "end_angle = np.random.randint(0, 360, size=(n_circles))\n",
+    "start_angle = 0\n",
+    "end_angle = math.pi\n",
+    "start_angle = np.random.random(n_circles) * math.pi \n",
+    "end_angle = np.random.random(n_circles) * math.pi \n",
+    "alphas = np.random.random(n_circles)\n",
+    "with hold_canvas(canvas):\n",
+    "    canvas.fill_style = 'cyan'\n",
+    "    canvas.fill_arcs(x,y,r,start_angle, end_angle)\n",
+    "    canvas.line_width = 1\n",
+    "    canvas.stroke_style = 'black'\n",
+    "    canvas.stroke_arcs(x,y,r,start_angle, end_angle)\n",
+    "canvas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "549983e9-f9bb-4ca7-a024-8f1307f15ba8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Batch Draw Styled Arcs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "1e4431ab-e064-448d-ab72-decba895bb7c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "61b1d04c125d4420bebae9650ed99c58",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(height=300, width=800)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "canvas = Canvas(width=800, height=300)\n",
+    "n_circles = 20\n",
+    "x = np.random.randint(0, canvas.width, size=(n_circles))\n",
+    "y = np.random.randint(0, canvas.height, size=(n_circles))\n",
+    "r = np.random.randint(30, 50, size=(n_circles))\n",
+    "start_angle = np.random.random(n_circles) * math.pi \n",
+    "end_angle = np.random.random(n_circles) * math.pi \n",
+    "colors_fill = np.random.randint(0, 255, size=(n_circles,3))\n",
+    "colors_outline  = np.random.randint(0, 255, size=(n_circles,3))\n",
+    "alphas = np.random.random(n_circles)\n",
+    "with hold_canvas(canvas):\n",
+    "    canvas.fill_styled_arcs(x,y,r,start_angle, end_angle,color=colors_fill,alpha=1)\n",
+    "    canvas.line_width = 3\n",
+    "    canvas.stroke_styled_arcs(x,y,r,start_angle, end_angle,color=colors_outline,alpha=1)\n",
+    "canvas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afea33c6-c6a8-4528-a1d9-7535a6810e9a",
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Batch Draw Polygons / LineSegments\n",
     "## Case 1: All Polygons / LineSegments have the same number of points"
@@ -127,14 +325,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 52,
    "id": "885a5ec6-06a8-4430-815e-63c06f6fa2cb",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f0bfa8a9abe541059c8f0898e913b652",
+       "model_id": "8efa7e28168e4da1a69045f4865a68e3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -184,14 +382,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 33,
    "id": "6bf31d36-01af-484c-9360-b97f504532a2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "08ef9e57eb5f493697fc6aa2c63c32ac",
+       "model_id": "8915993f0f1a4f128ba7871a858cf99f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -239,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 34,
    "id": "34643bf9-d9d9-4296-aa02-67531e6f500f",
    "metadata": {
     "tags": []
@@ -248,7 +446,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "219e9b29162d4d5897d53a461c97c232",
+       "model_id": "751412241a3c4294a8323f61cd77e8f3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -295,14 +493,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 35,
    "id": "272deb5a-fc18-44b0-af01-04f3afb28247",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aa24d7e01ad04540be42d2702cb3ff74",
+       "model_id": "3af7556653c44b7ca378466c438d2016",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/batch_drawing.ipynb
+++ b/examples/batch_drawing.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "3ea1b15d-478b-41a2-83a1-3e66e5ff5d24",
    "metadata": {},
    "outputs": [],
@@ -33,25 +33,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "7de46419-aefa-4039-a27c-ad92f903a5ff",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4f16d21e2fa442d9b215ed9f5c7b7ef3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=300, width=800)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=800, height=300)\n",
     "n_rects = 1000\n",
@@ -78,25 +63,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "f051cd10-5cf3-4a6f-bcb3-d10d5528c185",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b9af46082601430fabb28f7dc57484a7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=300, width=800)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=800, height=300)\n",
     "n_rects = 1000\n",
@@ -127,27 +97,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "id": "82b532b6-06b0-4255-b4fa-e03a6363ddf0",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2d3f918019954eb49bf2e2985a2f152c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=300, width=800)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=800, height=300)\n",
     "# draw n circles with and random radii, random colors, and random alpha values\n",
@@ -177,25 +132,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "id": "ce545eee-d9c0-47ab-afb7-274fa22389cd",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "11134765d61041fd9395b155ef309910",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=300, width=800)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=800, height=300)\n",
     "n_circles = 1000\n",
@@ -222,25 +162,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "id": "e36c1407-9a46-42fa-b06a-1a8283feee86",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "66ae6bd2dbfe4d4eb530b33054e1d2ba",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=300, width=800)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=800, height=300)\n",
     "n_circles = 1000\n",
@@ -275,25 +200,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "id": "1e4431ab-e064-448d-ab72-decba895bb7c",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "61b1d04c125d4420bebae9650ed99c58",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=300, width=800)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=800, height=300)\n",
     "n_circles = 20\n",
@@ -325,25 +235,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "id": "885a5ec6-06a8-4430-815e-63c06f6fa2cb",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8efa7e28168e4da1a69045f4865a68e3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=300, width=800)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=800, height=300)\n",
     "n_polygons = 50\n",
@@ -382,25 +277,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "6bf31d36-01af-484c-9360-b97f504532a2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8915993f0f1a4f128ba7871a858cf99f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=300, width=800)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=800, height=300)\n",
     "\n",
@@ -437,27 +317,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "34643bf9-d9d9-4296-aa02-67531e6f500f",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "751412241a3c4294a8323f61cd77e8f3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=400, width=400)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=400, height=400)\n",
     "\n",
@@ -493,25 +358,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "272deb5a-fc18-44b0-af01-04f3afb28247",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3af7556653c44b7ca378466c438d2016",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(height=400, width=400)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "canvas = Canvas(width=400, height=400)\n",
     "n_polygons = 20\n",

--- a/ipycanvas/canvas.py
+++ b/ipycanvas/canvas.py
@@ -20,20 +20,20 @@ from ._frontend import module_name, module_version
 
 from .utils import binary_image, populate_args, image_bytes_to_array, commands_to_buffer
 
-COMMANDS = {
-    'fillRect': 0, 'strokeRect': 1, 'fillRects': 2, 'strokeRects': 3, 'clearRect': 4, 'fillArc': 5,
-    'fillCircle': 6, 'strokeArc': 7, 'strokeCircle': 8, 'fillArcs': 9, 'strokeArcs': 10,
-    'fillCircles': 11, 'strokeCircles': 12, 'strokeLine': 13, 'beginPath': 14, 'closePath': 15,
-    'stroke': 16, 'fillPath': 17, 'fill': 18, 'moveTo': 19, 'lineTo': 20,
-    'rect': 21, 'arc': 22, 'ellipse': 23, 'arcTo': 24, 'quadraticCurveTo': 25,
-    'bezierCurveTo': 26, 'fillText': 27, 'strokeText': 28, 'setLineDash': 29, 'drawImage': 30,
-    'putImageData': 31, 'clip': 32, 'save': 33, 'restore': 34, 'translate': 35,
-    'rotate': 36, 'scale': 37, 'transform': 38, 'setTransform': 39, 'resetTransform': 40,
-    'set': 41, 'clear': 42, 'sleep': 43, 'fillPolygon': 44, 'strokePolygon': 45,
-    'strokeLines': 46, 'fillPolygons': 47, 'strokePolygons': 48, 'strokeLineSegments': 49,
-    'fillStyledCircles': 50, 'strokeStyledCircles': 51, 'fillStyledPolygons': 52,
-    'strokeStyledPolygons': 53, 'strokeStyledLineSegments': 54
-}
+_CMD_LIST = ['fillRect', 'strokeRect', 'fillRects', 'strokeRects', 'clearRect', 'fillArc',
+             'fillCircle', 'strokeArc', 'strokeCircle', 'fillArcs', 'strokeArcs',
+             'fillCircles', 'strokeCircles', 'strokeLine', 'beginPath', 'closePath',
+             'stroke', 'fillPath', 'fill', 'moveTo', 'lineTo',
+             'rect', 'arc', 'ellipse', 'arcTo', 'quadraticCurveTo',
+             'bezierCurveTo', 'fillText', 'strokeText', 'setLineDash', 'drawImage',
+             'putImageData', 'clip', 'save', 'restore', 'translate',
+             'rotate', 'scale', 'transform', 'setTransform', 'resetTransform',
+             'set', 'clear', 'sleep', 'fillPolygon', 'strokePolygon',
+             'strokeLines', 'fillPolygons', 'strokePolygons', 'strokeLineSegments',
+             'fillStyledRects', 'strokeStyledRects', 'fillStyledCircles', 'strokeStyledCircles',
+             'fillStyledArcs', 'strokeStyledArcs', 'fillStyledPolygons',
+             'strokeStyledPolygons', 'strokeStyledLineSegments']
+COMMANDS = {v: i for i, v in enumerate(_CMD_LIST)}
 
 
 # Traitlets does not allow validating without creating a trait class, so we need this
@@ -500,7 +500,7 @@ class Canvas(_CanvasBase):
         self._send_canvas_command(COMMANDS['fillRects'], args, buffers)
 
     def stroke_rects(self, x, y, width, height=None):
-        """Draw a rectangular outlines of sizes ``(width, height)`` at the ``(x, y)`` positions.
+        """Draw a rectangular outlines of sizes ``(width, height)`` at the ``(x, y)`` positions.of sizes ``(width, height)`
 
         Where ``x``, ``y``, ``width`` and ``height`` arguments are NumPy arrays, lists or scalar values.
         If ``height`` is None, it is set to the same value as width.
@@ -591,6 +591,54 @@ class Canvas(_CanvasBase):
 
         self._send_canvas_command(COMMANDS['fillCircles'], args, buffers)
 
+    def fill_styled_rects(self, x, y, width, height, color, alpha):
+        """Draw filled and styled rectangles of sizes ``(width, height)`` at the ``(x, y)`` positions
+
+        Where ``x``, ``y``, ``width`` and ``height`` arguments are NumPy arrays, lists or scalar values.
+        If ``height`` is None, it is set to the same value as width.
+        ``color`` is an (n_rect x 3) NumPy array with the colors and ``alpha`` is an (n_rect) NumPy array
+        with the alpha channel values.
+        """
+        args = []
+        buffers = []
+
+        populate_args(x, args, buffers)
+        populate_args(y, args, buffers)
+        populate_args(width, args, buffers)
+
+        if height is None:
+            args.append(args[-1])
+        else:
+            populate_args(height, args, buffers)
+
+        populate_args(color, args, buffers)
+        populate_args(alpha, args, buffers)
+        self._send_canvas_command(COMMANDS['fillStyledRects'], args, buffers)
+
+    def stroke_styled_rects(self, x, y, width, height, color, alpha):
+        """Draw rectangular styled outlines of sizes ``(width, height)`` at the ``(x, y)`` positions.of sizes ``(width, height)`
+
+        Where ``x``, ``y``, ``width`` and ``height`` arguments are NumPy arrays, lists or scalar values.
+        If ``height`` is None, it is set to the same value as width.
+        ``color`` is an (n_rect x 3) NumPy array with the colors and ``alpha`` is an (n_rect) NumPy array
+        with the alpha channel values.
+        """
+        args = []
+        buffers = []
+
+        populate_args(x, args, buffers)
+        populate_args(y, args, buffers)
+        populate_args(width, args, buffers)
+
+        if height is None:
+            args.append(args[-1])
+        else:
+            populate_args(height, args, buffers)
+
+        populate_args(color, args, buffers)
+        populate_args(alpha, args, buffers)
+        self._send_canvas_command(COMMANDS['strokeStyledRects'], args, buffers)
+
     def fill_styled_circles(self, x, y, radius, color, alpha):
         """Draw a filled circles centered at ``(x, y)`` with a radius of ``radius``.
 
@@ -622,6 +670,44 @@ class Canvas(_CanvasBase):
         populate_args(color, args, buffers)
         populate_args(alpha, args, buffers)
         self._send_canvas_command(COMMANDS['strokeStyledCircles'], args, buffers)
+
+    def fill_styled_arcs(self, x, y, radius, start_angle, end_angle, color, alpha, anticlockwise=False):
+        """Draw filled and styled arcs centered at ``(x, y)`` with a radius of ``radius``.
+
+        Where ``x``, ``y``, ``radius`` and other arguments are NumPy arrays, lists or scalar values.
+        """
+        args = []
+        buffers = []
+
+        populate_args(x, args, buffers)
+        populate_args(y, args, buffers)
+        populate_args(radius, args, buffers)
+        populate_args(start_angle, args, buffers)
+        populate_args(end_angle, args, buffers)
+        args.append(anticlockwise)
+        populate_args(color, args, buffers)
+        populate_args(alpha, args, buffers)
+
+        self._send_canvas_command(COMMANDS['fillStyledArcs'], args, buffers)
+
+    def stroke_styled_arcs(self, x, y, radius, start_angle, end_angle, color, alpha, anticlockwise=False):
+        """Draw an styled arc outlines centered at ``(x, y)`` with a radius of ``radius``.
+
+        Where ``x``, ``y``, ``radius`` and other arguments are NumPy arrays, lists or scalar values.
+        """
+        args = []
+        buffers = []
+
+        populate_args(x, args, buffers)
+        populate_args(y, args, buffers)
+        populate_args(radius, args, buffers)
+        populate_args(start_angle, args, buffers)
+        populate_args(end_angle, args, buffers)
+        args.append(anticlockwise)
+        populate_args(color, args, buffers)
+        populate_args(alpha, args, buffers)
+
+        self._send_canvas_command(COMMANDS['strokeStyledArcs'], args, buffers)
 
     def _draw_polygons_or_linesegments(self, cmd, points, color, alpha, points_per_item, with_style, min_elements, item_name):
         args = []

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -72,10 +72,10 @@ const COMMANDS = [
   'putImageData', 'clip', 'save', 'restore', 'translate',
   'rotate', 'scale', 'transform', 'setTransform', 'resetTransform',
   'set', 'clear', 'sleep', 'fillPolygon', 'strokePolygon',
-  'strokeLines',
-  'fillPolygons','strokePolygons','strokeLineSegments',
-  'fillStyledCircles','strokeStyledCircles','fillStyledPolygons',
-  'strokeStyledPolygons','strokeStyledLineSegments'
+  'strokeLines','fillPolygons','strokePolygons','strokeLineSegments',
+  'fillStyledRects', 'strokeStyledRects', 'fillStyledCircles','strokeStyledCircles',
+  'fillStyledArcs', 'strokeStyledArcs', 'fillStyledPolygons',
+  'strokeStyledPolygons','strokeStyledLineSegments',
 ];
 
 
@@ -403,11 +403,23 @@ class CanvasModel extends DOMWidgetModel {
       case 'strokeLineSegments':
         await this.drawPolygonOrLineSegments(args, buffers, false, false)
         break
+      case 'fillStyledRects':
+        await this.drawStyledRects(args, buffers, true)
+        break;
+      case 'strokeStyledRects':
+        await this.drawStyledRects(args, buffers, false)
+        break;
       case 'fillStyledCircles':
         await this.drawStyledCircles(args, buffers, true)
         break;
       case 'strokeStyledCircles':
         await this.drawStyledCircles(args, buffers, false)
+        break;
+      case 'fillStyledArcs':
+        await this.drawStyledArcs(args, buffers, true)
+        break;
+      case 'strokeStyledArcs':
+        await this.drawStyledArcs(args, buffers, false)
         break;
       case 'fillStyledPolygons':
         await this.drawStyledPolygonOrLineSegments(args, buffers, true, true)
@@ -455,6 +467,30 @@ class CanvasModel extends DOMWidgetModel {
       callback(x.getItem(idx), y.getItem(idx), width.getItem(idx), height.getItem(idx));
     }
   }
+  private drawStyledRects(args: any[], buffers: any, fill: boolean){
+    const x = getArg(args[0], buffers);
+    const y = getArg(args[1], buffers);
+    const width = getArg(args[2], buffers);
+    const height = getArg(args[3], buffers);
+    const colors = getArg(args[4], buffers);
+    const alpha = getArg(args[5], buffers);
+
+    const numberRects = Math.min(x.length, y.length,  width.length, height.length);
+    this.ctx.save()
+    for (let idx = 0; idx < numberRects; ++idx) {
+        // get color for this circle
+        const ci = 3*idx
+        const color = `rgba(${colors.getItem(ci)}, ${colors.getItem(ci+1)}, ${colors.getItem(ci+2)}, ${alpha.getItem(idx)})`;
+        this.setStyle(color, fill)
+        if(fill)
+        {
+          this.fillRect(x.getItem(idx), y.getItem(idx), width.getItem(idx), height.getItem(idx));
+        }else{
+          this.strokeRect(x.getItem(idx), y.getItem(idx), width.getItem(idx), height.getItem(idx));
+        }
+    }
+    this.ctx.restore()
+  }
 
   protected fillArc(x: number, y: number, radius: number, startAngle: number, endAngle: number, anticlockwise: boolean) {
     this.ctx.beginPath();
@@ -498,6 +534,7 @@ class CanvasModel extends DOMWidgetModel {
       )
     }
   }
+
 
   protected fillCircle(x: number, y: number, radius: number) {
     this.ctx.beginPath();
@@ -559,6 +596,41 @@ class CanvasModel extends DOMWidgetModel {
     }
     this.ctx.restore()
   }
+
+ private drawStyledArcs(args: any[], buffers: any, fill: boolean){
+    const x = getArg(args[0], buffers);
+    const y = getArg(args[1], buffers);
+    const radius = getArg(args[2], buffers);
+    const startAngle = getArg(args[3], buffers);
+    const endAngle = getArg(args[4], buffers);
+    const anticlockwise = getArg(args[5], buffers);
+    const colors = getArg(args[6], buffers);
+    const alpha = getArg(args[7], buffers);
+
+    const numberArcs = Math.min(
+      x.length, y.length, radius.length,
+      startAngle.length, endAngle.length
+    );
+    this.ctx.save()
+    for (let idx = 0; idx < numberArcs; ++idx) {
+        // get color for this circle
+        const ci = 3*idx
+        const color = `rgba(${colors.getItem(ci)}, ${colors.getItem(ci+1)}, ${colors.getItem(ci+2)}, ${alpha.getItem(idx)})`;
+        this.setStyle(color, fill)
+        if(fill)
+        {
+          this.fillArc(x.getItem(idx), y.getItem(idx), radius.getItem(idx),
+            startAngle.getItem(idx), endAngle.getItem(idx),
+            anticlockwise.getItem(idx));
+        }else{
+          this.strokeArc(x.getItem(idx), y.getItem(idx), radius.getItem(idx),
+            startAngle.getItem(idx), endAngle.getItem(idx),
+            anticlockwise.getItem(idx));
+        }
+    }
+    this.ctx.restore()
+  }
+
 
   private drawStyledPolygonOrLineSegments(args: any[], buffers: any, fill: boolean, close: boolean){
 


### PR DESCRIPTION
* missing styled methods:
    * `fill_styled_rects` /  `stroke_styled_rects`
    * `fill_styled_arcs` /  `stroke_styled_arcs`
* updated example
* auto creating dict of commands from list of commands to avoid hand-enumerating of commands on python side