### PR TITLE
fix wrong ver

### DIFF
--- a/ipycanvas/_frontend.py
+++ b/ipycanvas/_frontend.py
@@ -9,4 +9,4 @@ Information about the frontend package of the widgets.
 """
 
 module_name = "ipycanvas"
-module_version = "^0.9.0"
+module_version = "^0.10.0"


### PR DESCRIPTION
currently ipycanvas does not start when installed from conda when using 0.10.0
the debug output shows 
```
2523.cf94b68f6edde7eefd61.js:1 Uncaught (in promise) Error: Module ipycanvas, semver range ^0.9.0 is not registered as a widget module
    at x.loadClass (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/523.cf94b68f6edde7eefd61.js:1)
    at x.<anonymous> (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1
    at Object.next (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1
    at new Promise (<anonymous>)
    at S (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at x.e._make_model (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at x.<anonymous> (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1
2523.cf94b68f6edde7eefd61.js:1 Uncaught (in promise) Error: Module ipycanvas, semver range ^0.9.0 is not registered as a widget module
    at x.loadClass (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/523.cf94b68f6edde7eefd61.js:1)
    at x.<anonymous> (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1
    at Object.next (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1
    at new Promise (<anonymous>)
    at S (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at x.e._make_model (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at x.<anonymous> (lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1)
    at lab/extensions/@jupyter-widgets/jupyterlab-manager/static/272.9d70a85a9abe209402d0.js:1
```
I think this is due to a missing version bump in `ipycanvas/_frontend.py`.
I think this makes the 0.10.0 release a broken one