### PR TITLE
Modernize js output.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lib/**/*.js",
     "lib/**/*.d.ts",
     "dist/*.js",
-    "dist/*.d.ts"
+    "dist/*.d.ts",
+    "dist/*.map",
+    "dist/*.LICENSE.txt"
   ],
   "homepage": "https://github.com/martinRenou/ipycanvas",
   "bugs": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "lib": ["es2015", "dom"],
-    "module": "commonjs",
+    "module": "ES2015",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noUnusedLocals": true,
@@ -15,7 +14,7 @@
     // This allows us to initialize members in the "initialize" method
     "strictPropertyInitialization": false,
     "strict": true,
-    "target": "es2015"
+    "target": "ES2017"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
This upgrades the output to es2017 (with es2015 modules generated rather than commonjs), which supports async natively, which makes it *much* easier to debug async functions in the generated js.