### PR TITLE
Update the requested frontend version to ^0.13.0

### DIFF
--- a/ipycanvas/_frontend.py
+++ b/ipycanvas/_frontend.py
@@ -9,4 +9,4 @@ Information about the frontend package of the widgets.
 """
 
 module_name = "ipycanvas"
-module_version = "^0.12"
+module_version = "^0.13.0"


### PR DESCRIPTION
This was not updated in the recent 0.13 release, and ^0.12 means 0.12.*, so it breaks ipycanvas (i.e., the backend is requesting ^0.12, but all the frontend has is 0.13).

Can we release a 0.13.1 with this change?

Also, a post-1.0 version number would be more forgiving about this, e.g., ^1.12 includes 1.13, but ^0.12 does not include 0.13.